### PR TITLE
:recycle: add ability to bypass DCT filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /test/version_tmp/
 /tmp/
 /mindee-*/
+/vendor
 
 # Used by dotenv library to load environment variables.
 .env

--- a/lib/origami/graphics/xobject.rb
+++ b/lib/origami/graphics/xobject.rb
@@ -694,12 +694,12 @@ module Origami
             #
             #   Returns an array of the form [ _format_, _data_ ]
             #
-            def to_image_file
+            def to_image_file(bypass_dct: false)
                 encoding = self.Filter
                 encoding = encoding[0] if encoding.is_a? ::Array
 
                 case (encoding && encoding.value)
-                when :DCTDecode then return [ 'jpg', self.data ]
+                when :DCTDecode then return [ 'jpg', self.data(bypass_dct: bypass_dct) ]
                 when :JBIG2Decode then return [ 'jbig2', self.data ]
                 when :JPXDecode then return [ 'jp2', self.data ]
                 end

--- a/lib/origami/stream.rb
+++ b/lib/origami/stream.rb
@@ -233,8 +233,8 @@ module Origami
         #
         # Returns the uncompressed stream content.
         #
-        def data
-            self.decode! unless decoded?
+        def data(bypass_dct: false)
+            self.decode!(bypass_dct: bypass_dct) unless decoded?
 
             @data
         end
@@ -269,9 +269,9 @@ module Origami
         end
 
         #
-        # Uncompress the stream data.
+        # Decompress the stream data.
         #
-        def decode!
+        def decode!(bypass_dct: false)
             self.decrypt! if self.is_a?(Encryption::EncryptedStream)
             return if decoded?
 
@@ -289,6 +289,11 @@ module Origami
                     raise Filter::Error, "Crypt filter must be the first filter" unless layer.zero?
 
                     # Skip the Crypt filter.
+                    next
+                end
+
+                # Manually Bypass DCTDecode. Only used when already compressed jpegs are loaded in an xobject.
+                if filter == :DCTDecode && bypass_dct
                     next
                 end
 


### PR DESCRIPTION
Loading jpegs through xobjects shouldn't go throught the DCT filter step. This bypasses that