### PR TITLE
Fix Ruby 3.4 syntax in Hash.new in instruction.rb

### DIFF
--- a/lib/origami/graphics/instruction.rb
+++ b/lib/origami/graphics/instruction.rb
@@ -28,7 +28,7 @@ module Origami
         attr_reader :operator
         attr_accessor :operands
 
-        @insns = Hash.new(operands: [], render: lambda{})
+        @insns = Hash.new({ operands: [], render: lambda{} })
 
         def initialize(operator, *operands)
             @operator = operator


### PR DESCRIPTION
This fixes issue like

```
ArgumentError: unknown keywords: :operands, :render (ArgumentError)
.../gems/origamindee-3.1.0/lib/origami/graphics/instruction.rb:31:in 'Class#new'
```